### PR TITLE
Added a generic is_connected property to base and NATS transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/
+venv/
+
 __pycache__
 *.egg-info/
 .cache

--- a/protokol/transports/base.py
+++ b/protokol/transports/base.py
@@ -19,3 +19,14 @@ class Transport:
 
     async def monitor(self, callback: Callable, **kwargs):
         raise NotImplementedError
+
+    @property
+    def is_connected(self) -> bool:
+        """
+            Generic property that shows whether the transport connection is "active"
+            and able to receive and send data.
+            Since this is a property, implementations should avoid altering the state
+            and generally stick to read-only flags available at request time.
+        :return: whether transport is ready to receive and send data
+        """
+        raise NotImplementedError

--- a/protokol/transports/nats.py
+++ b/protokol/transports/nats.py
@@ -30,3 +30,7 @@ class NatsTransport(Transport):
 
     async def monitor(self, callback: Callable, **kwargs):
         return await self._client.subscribe('*', cb=callback, **kwargs)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._client.is_connected


### PR DESCRIPTION
Adding a very simple is_connected property to transports.
Quick research has shown that there's no need to make the property async since clients usually use flags to represent the connection status.