### PR TITLE
Updated base NATS library, added connection args/kwargs propagation

### DIFF
--- a/protokol/transports/base.py
+++ b/protokol/transports/base.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 
 class Transport:
-    async def connect(self, url: str, **kwargs):
+    async def connect(self, *urls: str, **kwargs):
         raise NotImplementedError
 
     async def close(self):

--- a/protokol/transports/nats.py
+++ b/protokol/transports/nats.py
@@ -1,6 +1,7 @@
 import json
 from typing import Callable
-from nats.aio.client import Client, ErrTimeout
+from nats.aio.client import Client
+from nats.aio.errors import ErrTimeout
 
 from protokol.transports.base import Transport
 
@@ -9,8 +10,8 @@ class NatsTransport(Transport):
     def __init__(self):
         self._client = Client()
 
-    async def connect(self, url: str, **kwargs):
-        return await self._client.connect(url, **kwargs)
+    async def connect(self, *urls: str, **kwargs):
+        return await self._client.connect(list(urls), **kwargs)
 
     async def close(self):
         return await self._client.close()
@@ -26,7 +27,7 @@ class NatsTransport(Transport):
             result = await self._client.request(realm, json.dumps(message).encode(), **kwargs)
         except ErrTimeout:
             raise TimeoutError
-        return json.loads(result.data.decode())
+        return json.loads(result.data)
 
     async def monitor(self, callback: Callable, **kwargs):
         return await self._client.subscribe('*', cb=callback, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        "asyncio-nats-client",
+        "nats-py",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
nats-py has superseded asyncio-nats-client and is maintained by the same developer.
Its newest version (2.0.0) is still in rc stage though.

Also added transport connection args and kwargs propagation through Protokol.create() method since there was no way to customize connection save for subclassing a Transport implementation class